### PR TITLE
fix: make typing works as expect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 types
 coverage
+lib

--- a/package.json
+++ b/package.json
@@ -14,17 +14,19 @@
   "contributors": [
     "Sebastien Chopin (@Atinux)",
     "Clark Du (@clarkdo)",
-    "Pooya Parsa (@pi0)"
+    "Pooya Parsa (@pi0)",
+    "xcodebuild (@xcodebuild)"
   ],
-  "main": "./dist/hookable.js",
-  "browser": "./dist/hookable.min.js",
-  "types": "./types/hoookable.d.ts",
+  "main": "./lib/hookable.js",
+  "browser": "./lib/hookable.js",
+  "typings": "./lib/hoookable.d.ts",
   "files": [
     "dist",
-    "types"
+    "types",
+    "lib"
   ],
   "scripts": {
-    "build": "rollup -c && tsc --emitDeclarationOnly",
+    "build": "rollup -c && tsc",
     "prepublish": "yarn build",
     "lint": "eslint --ext .ts src",
     "release": "yarn test && yarn build && standard-version && git push --follow-tags && npm publish",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "importHelpers": false,
-    "noEmitHelpers": true,
+    "noEmitHelpers": false,
     "strict": true,
     "esModuleInterop": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,23 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "es5",
+    "module": "commonjs",
     "importHelpers": false,
     "noEmitHelpers": true,
     "strict": true,
     "esModuleInterop": true,
-    "outDir": "dist",
     "declaration": true,
-    "declarationDir": "types",
+    "declarationDir": "lib",
     "types": [
       "node"
     ],
+    "outDir": "./lib",
+    "rootDir": "./src",  
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "lib"
   ]
 }


### PR DESCRIPTION
- `types` should be `typeings`

### before
![image](https://user-images.githubusercontent.com/5436704/80471035-69f40480-8975-11ea-9fa1-c32fddc58487.png)

### fixed
![image](https://user-images.githubusercontent.com/5436704/80472729-b5a7ad80-8977-11ea-8453-79e23d95f145.png)


- It would be better to publish a `lib` after compile to ES5 for both `browser` and `nodejs`, or we will get something like `regerationRuntime not defined` after `require`.