### PR TITLE
feat: `mergeHooks` helper

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -1,10 +1,13 @@
-import { serial, flatHooks } from './utils'
+import { serial, flatHooks, mergeHooks } from './utils'
 import { LoggerT, hookFnT, configHooksT, deprecatedHookT, deprecatedHooksT } from './types'
 
-export default class Hookable {
+class Hookable {
   private _hooks: { [name: string]: hookFnT[] }
   private _deprecatedHooks: deprecatedHooksT
   private _logger: LoggerT | false
+
+  static mergeHooks: typeof mergeHooks
+  mergeHooks: typeof mergeHooks
 
   constructor (logger: LoggerT | false = console) {
     this._logger = logger
@@ -17,6 +20,11 @@ export default class Hookable {
   }
 
   hook (name: string, fn: hookFnT) {
+    if (Array.isArray(fn)) {
+      for (const _fn of fn) {
+        this.hook(name, _fn)
+      }
+    }
     if (!name || typeof fn !== 'function') {
       return () => {}
     }
@@ -124,3 +132,8 @@ export default class Hookable {
     }
   }
 }
+
+Hookable.mergeHooks = mergeHooks
+Hookable.prototype.mergeHooks = mergeHooks
+
+export default Hookable

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -20,11 +20,6 @@ class Hookable {
   }
 
   hook (name: string, fn: hookFnT) {
-    if (Array.isArray(fn)) {
-      for (const _fn of fn) {
-        this.hook(name, _fn)
-      }
-    }
     if (!name || typeof fn !== 'function') {
       return () => {}
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 export type unregHookT = () => void
 export type hookFnT = (...args: any) => Promise<void> | void
-export type configHooksT = { [name: string]: configHooksT | hookFnT | hookFnT }
+export type configHooksT = { [name: string]: configHooksT | hookFnT }
 export type deprecatedHookT = string | { message: string, to: string }
 export type deprecatedHooksT = { [name: string]: deprecatedHookT}
-export type flatHooksT = { [name: string]: hookFnT|hookFnT }
+export type flatHooksT = { [name: string]: hookFnT }
 
 export interface LoggerT {
   error(...args: any): void,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 export type unregHookT = () => void
 export type hookFnT = (...args: any) => Promise<void> | void
-export type configHooksT = { [name: string]: configHooksT | hookFnT }
+export type configHooksT = { [name: string]: configHooksT | hookFnT | hookFnT[] }
 export type deprecatedHookT = string | { message: string, to: string }
 export type deprecatedHooksT = { [name: string]: deprecatedHookT}
-export type flatHooksT = { [name: string]: hookFnT }
+export type flatHooksT = { [name: string]: hookFnT|hookFnT[] }
 
 export interface LoggerT {
   error(...args: any): void,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 export type unregHookT = () => void
 export type hookFnT = (...args: any) => Promise<void> | void
-export type configHooksT = { [name: string]: configHooksT | hookFnT | hookFnT[] }
+export type configHooksT = { [name: string]: configHooksT | hookFnT | hookFnT }
 export type deprecatedHookT = string | { message: string, to: string }
 export type deprecatedHooksT = { [name: string]: deprecatedHookT}
-export type flatHooksT = { [name: string]: hookFnT|hookFnT[] }
+export type flatHooksT = { [name: string]: hookFnT|hookFnT }
 
 export interface LoggerT {
   error(...args: any): void,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ export function flatHooks (configHooks: configHooksT, hooks: flatHooksT = {}, pa
   for (const key in configHooks) {
     const subHook = configHooks[key]
     const name = parentName ? `${parentName}:${key}` : key
-    if (typeof subHook === 'object' && subHook !== null && !Array.isArray(subHook)) {
+    if (typeof subHook === 'object' && subHook !== null) {
       flatHooks(subHook, hooks, name)
     } else if (typeof subHook === 'function') {
       hooks[name] = subHook

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,6 @@ export function mergeHooks (...hooks: configHooksT[]): flatHooksT {
     }
   }
 
-  // Merge to single function for backward compatibility
   for (const key in finalHooks) {
     const arr = finalHooks[key]
     finalHooks[key] = (...args) => serial(arr, (fn: any) => fn(...args))

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -275,4 +275,69 @@ describe('core: hookable', () => {
 
     expect(x).toBe(1)
   })
+
+  test('should call registered hooks (array)', async () => {
+    const hook = new Hookable()
+    hook.hook('test:hook', [
+      () => console.log('test:hook called1'),
+      () => console.log('test:hook called2')
+    ])
+
+    await hook.callHook('test:hook')
+
+    expect(console.log).toBeCalledWith('test:hook called1')
+    expect(console.log).toBeCalledWith('test:hook called2')
+  })
+
+  test('mergeHooks util', () => {
+    const fn = () => { }
+    const hooks1 = {
+      foo: fn,
+      bar: fn,
+      'a:b': fn,
+      'a:c': fn
+    }
+    const hooks2 = {
+      foo: fn,
+      baz: fn,
+      a: {
+        b: fn,
+        d: fn
+      }
+    }
+
+    const merged = Hookable.mergeHooks(hooks1, hooks2)
+
+    expect(Object.keys(merged)).toMatchObject([
+      'foo',
+      'bar',
+      'a:b',
+      'a:c',
+      'baz',
+      'a:d'
+    ])
+  })
+
+  test('mergeHooks util (proto)', async () => {
+    const hook = new Hookable()
+
+    const hooks1 = {
+      'test:hook': () => console.log('test:hook called1')
+    }
+
+    const hooks2 = {
+      test: {
+        hook: () => console.log('test:hook called2')
+      }
+    }
+
+    const mergedHooks = hook.mergeHooks(hooks1, hooks2)
+
+    hook.addHooks(mergedHooks)
+
+    await hook.callHook('test:hook')
+
+    expect(console.log).toBeCalledWith('test:hook called1')
+    expect(console.log).toBeCalledWith('test:hook called2')
+  })
 })

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -276,19 +276,6 @@ describe('core: hookable', () => {
     expect(x).toBe(1)
   })
 
-  test('should call registered hooks (array)', async () => {
-    const hook = new Hookable()
-    hook.hook('test:hook', [
-      () => console.log('test:hook called1'),
-      () => console.log('test:hook called2')
-    ])
-
-    await hook.callHook('test:hook')
-
-    expect(console.log).toBeCalledWith('test:hook called1')
-    expect(console.log).toBeCalledWith('test:hook called2')
-  })
-
   test('mergeHooks util', () => {
     const fn = () => { }
     const hooks1 = {


### PR DESCRIPTION
 Expose `Hookable.mergeHooks` and `hookable.mergeHooks` to merge multiple hook objects into single flattened one

```js
const hooks1 = {
  foo: fn,
  bar: fn,
  'a:b': fn,
  'a:c': fn
}

const hooks2 = {
  foo: fn,
  baz: fn,
  a: {
    b: fn,
    d: fn
  }
}

const merged = Hookable.mergeHooks(hooks1, hooks2)
```

It results into:

```
{
  foo: () => { },
  bar: () => { },
  'a:b': () => { },
  'a:c': () => { },
  baz: () => { },
  'a:d': () => { }
}
```
